### PR TITLE
Fix Android getname() and add start/oneShot functionality.

### DIFF
--- a/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
+++ b/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
@@ -40,7 +40,8 @@ public class RCTImageSequenceManager extends SimpleViewManager<RCTImageSequenceV
         ArrayList<String> uris = new ArrayList<>();
         for (int index = 0; index < images.size(); index++) {
             ReadableMap map = images.getMap(index);
-            uris.add(map.getString("uri"));
+            String uri = map.getString("uri");
+            uris.add(uri);
         }
 
         view.setImages(uris);

--- a/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
+++ b/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 public class RCTImageSequenceManager extends SimpleViewManager<RCTImageSequenceView> {
     @Override
     public String getName() {
-        return "RCTImageSequencePackage";
+	return "RCTImageSequence";
     }
 
     @Override

--- a/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
+++ b/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 public class RCTImageSequenceManager extends SimpleViewManager<RCTImageSequenceView> {
     @Override
     public String getName() {
-	return "RCTImageSequence";
+        return "RCTImageSequence";
     }
 
     @Override
@@ -44,5 +44,27 @@ public class RCTImageSequenceManager extends SimpleViewManager<RCTImageSequenceV
         }
 
         view.setImages(uris);
+    }
+
+    /**
+     * sets whether or not the animation starts automatically.
+     *
+     * @param view
+     * @param start
+     */
+    @ReactProp(name = "start")
+    public void setStart(final RCTImageSequenceView view, boolean start) {
+        view.setStart(start);
+    }
+
+    /**
+     * sets whether or not the animation plays endlessly or once
+     *
+     * @param view
+     * @param oneShot
+     */
+    @ReactProp(name = "oneShot")
+    public void setOneShot(final RCTImageSequenceView view, boolean oneShot) {
+        view.setOneShot(oneShot);
     }
 }

--- a/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
+++ b/android/src/main/java/dk/madslee/RCTImageSequenceManager.java
@@ -21,6 +21,17 @@ public class RCTImageSequenceManager extends SimpleViewManager<RCTImageSequenceV
     }
 
     /**
+     * sets the sample size of the image.
+     *
+     * @param view
+     * @param sampleSize
+     */
+    @ReactProp(name = "sampleSize")
+    public void setSampleSize(final RCTImageSequenceView view, Integer sampleSize) {
+        view.setSampleSize(sampleSize);
+    }
+
+    /**
      * sets the speed of the animation.
      *
      * @param view

--- a/android/src/main/java/dk/madslee/RCTImageSequenceView.java
+++ b/android/src/main/java/dk/madslee/RCTImageSequenceView.java
@@ -16,8 +16,11 @@ import java.util.HashMap;
 
 public class RCTImageSequenceView extends ImageView {
     private Integer framesPerSecond = 24;
+    private boolean start = true;
+    private boolean oneShot = false;
     private ArrayList<AsyncTask> activeTasks;
     private HashMap<Integer, Bitmap> bitmaps;
+    private AnimationDrawable animationDrawable;
 
     public RCTImageSequenceView(Context context) {
         super(context);
@@ -97,6 +100,31 @@ public class RCTImageSequenceView extends ImageView {
         }
     }
 
+    public void setStart(boolean start) {
+        this.start = start;
+
+        //Start again if already loaded.
+        if (start == true && isLoaded()) {
+            setupAnimationDrawable();
+        }
+    }
+
+    public void setOneShot(boolean oneShot) {
+        this.oneShot = oneShot;
+
+        //Start again if already loaded.
+        if (isLoaded() && null != this.animationDrawable) {
+            this.animationDrawable.setOneShot(oneShot);
+        }
+    }
+
+    public void start() {
+        if (null != this.animationDrawable) {
+            this.animationDrawable.setOneShot(this.oneShot);
+            this.animationDrawable.start();
+        }
+    }
+
     private boolean isLoaded() {
         return !isLoading() && bitmaps != null && !bitmaps.isEmpty();
     }
@@ -106,15 +134,16 @@ public class RCTImageSequenceView extends ImageView {
     }
 
     private void setupAnimationDrawable() {
-        AnimationDrawable animationDrawable = new AnimationDrawable();
+        this.animationDrawable = new AnimationDrawable();
         for (int index = 0; index < bitmaps.size(); index++) {
             BitmapDrawable drawable = new BitmapDrawable(this.getResources(), bitmaps.get(index));
-            animationDrawable.addFrame(drawable, 1000 / framesPerSecond);
+            this.animationDrawable.addFrame(drawable, 1000 / framesPerSecond);
         }
 
-        animationDrawable.setOneShot(false);
-        animationDrawable.start();
+        if (start == true) {
+            start();
+        }
 
-        this.setImageDrawable(animationDrawable);
+        this.setImageDrawable(this.animationDrawable);
     }
 }

--- a/android/src/main/java/dk/madslee/RCTImageSequenceView.java
+++ b/android/src/main/java/dk/madslee/RCTImageSequenceView.java
@@ -26,6 +26,7 @@ public class RCTImageSequenceView extends ImageView {
     private Integer framesPerSecond = 24;
     private boolean start = true;
     private boolean oneShot = false;
+    private Integer sampleSize = 1;
     private ArrayList<AsyncTask> activeTasks;
     private HashMap<Integer, Bitmap> bitmaps;
     private AnimationDrawable animationDrawable;
@@ -54,10 +55,14 @@ public class RCTImageSequenceView extends ImageView {
             try {
                 InputStream in;
                 if (this.uri.startsWith("http") == true) {
-                  in = new URL(this.uri).openStream();
-                  bitmap = BitmapFactory.decodeStream(in);
+                    in = new URL(this.uri).openStream();
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inSampleSize = sampleSize;
+                    bitmap = BitmapFactory.decodeStream(in, null, options);
                 } else {
-                  bitmap = BitmapFactory.decodeResource(mThemedReactContext.getResources(), mThemedReactContext.getResources().getIdentifier(this.uri , "drawable", mThemedReactContext.getPackageName()));
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inSampleSize = sampleSize;
+                    bitmap = BitmapFactory.decodeResource(mThemedReactContext.getResources(), mThemedReactContext.getResources().getIdentifier(this.uri , "drawable", mThemedReactContext.getPackageName()), options);
                 }
             } catch (IOException e) {
                 WritableMap eventParams = Arguments.createMap();
@@ -115,6 +120,14 @@ public class RCTImageSequenceView extends ImageView {
             sendEvent("onLoadStart", eventParams);
 
             task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        }
+    }
+
+    public void setSampleSize(Integer sampleSize) {
+        this.sampleSize = sampleSize;
+        // updating sample size
+        if (isLoaded()) {
+            setupAnimationDrawable();
         }
     }
 

--- a/android/src/main/java/dk/madslee/RCTImageSequenceView.java
+++ b/android/src/main/java/dk/madslee/RCTImageSequenceView.java
@@ -53,7 +53,7 @@ public class RCTImageSequenceView extends ImageView {
 
             try {
                 InputStream in;
-                if (this.uri.matches("^http")) {
+                if (this.uri.startsWith("http") == true) {
                   in = new URL(this.uri).openStream();
                   bitmap = BitmapFactory.decodeStream(in);
                 } else {

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ class ImageSequence extends React.Component {
 ImageSequence.propTypes = {
   startFrameIndex: React.PropTypes.number,
   images: React.PropTypes.array.isRequired,
+  sampleSize: React.PropTypes.number,
   framesPerSecond: React.PropTypes.number,
   start: React.PropTypes.bool,
   oneShot: React.PropTypes.bool,
@@ -49,6 +50,7 @@ ImageSequence.propTypes = {
 
 ImageSequence.defaultProps = {
   startFrameIndex: 0,
+  sampleSize: 1,
   framesPerSecond: 24,
   start: true,
   oneShot: false
@@ -60,6 +62,7 @@ const RCTImageSequence = requireNativeComponent('RCTImageSequence', {
     images: React.PropTypes.arrayOf(React.PropTypes.shape({
       uri: React.PropTypes.string.isRequired
     })).isRequired,
+    sampleSize: React.PropTypes.number,
     framesPerSecond: React.PropTypes.number,
     start: React.PropTypes.bool,
     oneShot: React.PropTypes.bool,

--- a/index.js
+++ b/index.js
@@ -25,12 +25,16 @@ class ImageSequence extends Component {
 ImageSequence.defaultProps = {
   startFrameIndex: 0,
   framesPerSecond: 24,
+  start: true,
+  oneShot: false
 };
 
 ImageSequence.propTypes = {
   startFrameIndex: React.PropTypes.number,
   images: React.PropTypes.array.isRequired,
-  framesPerSecond: React.PropTypes.number
+  framesPerSecond: React.PropTypes.number,
+  start: React.PropTypes.bool,
+  oneShot: React.PropTypes.bool
 };
 
 const RCTImageSequence = requireNativeComponent('RCTImageSequence', {
@@ -39,7 +43,9 @@ const RCTImageSequence = requireNativeComponent('RCTImageSequence', {
     images: React.PropTypes.arrayOf(React.PropTypes.shape({
       uri: React.PropTypes.string.isRequired
     })).isRequired,
-    framesPerSecond: React.PropTypes.number
+    framesPerSecond: React.PropTypes.number,
+    start: React.PropTypes.bool,
+    oneShot: React.PropTypes.bool
   },
 });
 

--- a/index.js
+++ b/index.js
@@ -1,25 +1,50 @@
-import React, { Component } from 'react';
-import {
-  View,
-  requireNativeComponent
-} from 'react-native';
-import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
+import React from 'react';
+import { View, requireNativeComponent, DeviceEventEmitter } from 'react-native';
+import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource'
 
-class ImageSequence extends Component {
+class ImageSequence extends React.Component {
+  componentWillMount() {
+    DeviceEventEmitter.addListener('onLoadStart', (event: Event) => {
+      if (this.props.onLoadStart) {
+        this.props.onLoadStart(event)
+      }
+    })
+    DeviceEventEmitter.addListener('onLoadComplete', (event: Event) => {
+      if (this.props.onLoadComplete) {
+        this.props.onLoadComplete(event)
+      }
+    })
+    DeviceEventEmitter.addListener('onError', (event: Event) => {
+      if (this.props.onError) {
+        this.props.onError(event)
+      }
+    })
+  }
   render() {
-    let normalized = this.props.images.map(resolveAssetSource);
+    let normalized = this.props.images.map(resolveAssetSource)
 
     // reorder elements if start-index is different from 0 (beginning)
     if (this.props.startFrameIndex !== 0) {
-      normalized = [...normalized.slice(this.props.startFrameIndex), ...normalized.slice(0, this.props.startFrameIndex)];
+      normalized = [...normalized.slice(this.props.startFrameIndex), ...normalized.slice(0, this.props.startFrameIndex)]
     }
 
     return (
       <RCTImageSequence
         {...this.props}
         images={normalized} />
-    );
+    )
   }
+}
+
+ImageSequence.propTypes = {
+  startFrameIndex: React.PropTypes.number,
+  images: React.PropTypes.array.isRequired,
+  framesPerSecond: React.PropTypes.number,
+  start: React.PropTypes.bool,
+  oneShot: React.PropTypes.bool,
+  onLoadStart: React.PropTypes.func,
+  onLoadComplete: React.PropTypes.func,
+  onError: React.PropTypes.func
 }
 
 ImageSequence.defaultProps = {
@@ -27,15 +52,7 @@ ImageSequence.defaultProps = {
   framesPerSecond: 24,
   start: true,
   oneShot: false
-};
-
-ImageSequence.propTypes = {
-  startFrameIndex: React.PropTypes.number,
-  images: React.PropTypes.array.isRequired,
-  framesPerSecond: React.PropTypes.number,
-  start: React.PropTypes.bool,
-  oneShot: React.PropTypes.bool
-};
+}
 
 const RCTImageSequence = requireNativeComponent('RCTImageSequence', {
   propTypes: {
@@ -45,8 +62,11 @@ const RCTImageSequence = requireNativeComponent('RCTImageSequence', {
     })).isRequired,
     framesPerSecond: React.PropTypes.number,
     start: React.PropTypes.bool,
-    oneShot: React.PropTypes.bool
+    oneShot: React.PropTypes.bool,
+    onLoadStart: React.PropTypes.func,
+    onLoadComplete: React.PropTypes.func,
+    onError: React.PropTypes.func
   },
-});
+})
 
-export default ImageSequence;
+export default ImageSequence


### PR DESCRIPTION
I had to make a fix to the RCTImageSequenceManager getName method so that it passed the same string the index.js was expecting. This fixed an issue where Android was not working at all.

I also added a couple new attributes for Android *only*.

`start` -> Defaults to `true`, set to `false` to delay the start of the animation until you want it to start by flipping to `true`

`oneShot` => Ties directly to the oneShot method that determines whether or not the animation loops or plays once.

I will need to follow up with similar iOS functionality in the future, but for now it was not needed, hence only half the work!