### PR TITLE
Fix crash when not being able to schedule task on busy devices

### DIFF
--- a/android/src/main/java/dk/madslee/imageSequence/RCTImageSequenceView.java
+++ b/android/src/main/java/dk/madslee/imageSequence/RCTImageSequenceView.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.BitmapDrawable;
+import android.util.Log;
 import android.os.AsyncTask;
 import android.widget.ImageView;
 
@@ -13,6 +14,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.RejectedExecutionException;
+
 
 public class RCTImageSequenceView extends ImageView {
     private Integer framesPerSecond = 24;
@@ -101,7 +104,12 @@ public class RCTImageSequenceView extends ImageView {
             DownloadImageTask task = new DownloadImageTask(index, uris.get(index), getContext());
             activeTasks.add(task);
 
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            try {
+                task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            } catch (RejectedExecutionException e){
+                Log.e("react-native-image-sequence", "DownloadImageTask failed" + e.getMessage());
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Old Android devices running newer version of React Native (0.40+) we observed the task thread pool to be exhausted. It fails with an `java.util.concurrent.ThreadPoolExecutor` exception.

To avoid crashing the app, this PR catches this exception.

I guess the underlying issue is that we load the same image multiple times. So if this lib is used for showing a list of images inside a component, then every time this component is loaded (or if there is multiple instances of it on a page), then we will spawn an async task. 

Maybe react-native-image-sequence should cache which images is already loaded?