### PR TITLE
add prop-types for RN >= 0.49

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import {
   requireNativeComponent,
   ViewPropTypes
 } from 'react-native';
+import { string, number, array, shape, arrayOf } from 'prop-types';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 class ImageSequence extends Component {
@@ -29,18 +30,18 @@ ImageSequence.defaultProps = {
 };
 
 ImageSequence.propTypes = {
-  startFrameIndex: React.PropTypes.number,
-  images: React.PropTypes.array.isRequired,
-  framesPerSecond: React.PropTypes.number
+  startFrameIndex: number,
+  images: array.isRequired,
+  framesPerSecond: number
 };
 
 const RCTImageSequence = requireNativeComponent('RCTImageSequence', {
   propTypes: {
     ...ViewPropTypes,
-    images: React.PropTypes.arrayOf(React.PropTypes.shape({
-      uri: React.PropTypes.string.isRequired
+    images: arrayOf(shape({
+      uri: string.isRequired
     })).isRequired,
-    framesPerSecond: React.PropTypes.number
+    framesPerSecond: number
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "url": "http://mads-lee.dk"
   },
   "peerDependencies": {
-    "react-native": ">=0.47.0"
+    "react-native": ">=0.47.0",
+    "prop-types": ">=15.5.0"
   },
   "license": "MIT",
   "homepage": "https://github.com/madsleejensen/react-native-image-sequence",


### PR DESCRIPTION
React Native 0.49 removed support for `React.PropTypes`