### PR TITLE
add podspec file

### DIFF
--- a/RCTImageSequence.podspec
+++ b/RCTImageSequence.podspec
@@ -1,0 +1,19 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name            = "RCTImageSequence"
+  s.version         = version
+  s.homepage        = "https://github.com/madsleejensen/react-native-image-sequence"
+  s.summary         = "A <ImageSequence> component for react-native"
+  s.license         = "MIT"
+  s.author          = { "Mads Lee Jensen" => "madsleejensen@gmail.com" }
+  s.ios.deployment_target = '7.0'
+  s.source          = { :git => "https://github.com/madsleejensen/react-native-image-sequence.git", :tag => "#{s.version}" }
+  s.source_files    = 'RCTImageSequence/*.{h,m}'
+  s.preserve_paths  = "**/*.js"
+  
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
When run pod install in an exists iOS app to Integrate react-native-image-sequence will get error like this:
[!] No podspec found for RCTImageSequence in ./node_modules/react-native-image-sequence
I have to add podspec file manually. So, I recommend adding podspec file into project.