### PR TITLE
Use unbounded queue for the img download executor

### DIFF
--- a/react-native-image-sequence.podspec
+++ b/react-native-image-sequence.podspec
@@ -10,7 +10,7 @@ require "json"
   s.homepage     = package["homepage"]
   s.license      = package["license"]
   s.platform     = :ios, "9.0"
-  s.source       = {:git => "https://github.com/madsleejensen/react-native-image-sequence.git" }
+  s.source       = {:git => "https://github.com/shanereid/react-native-image-sequence.git" }
   s.source_files  = "ios/RCTImageSequence/*.{h,m}"
   s.dependency "React"
 end


### PR DESCRIPTION
I had an issue where sequences containing a large amount of frames (150+) would fail to start on Android.

Turned out to be an issue with the default queue where tasks would be rejected if both the pool and queue were full, so the activeTasks list would never be empty and the animation would never be kicked off.

To fix this I used an unbounded queue.