### PR TITLE
Fix Android deprecation warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,9 @@ android {
     }
 }
 
+def supportLibVersion = getExtOrDefault('supportLibVersion', "28.0.0")
+
 dependencies {
+    implementation "com.android.support:support-compat:$supportLibVersion"
     compile 'com.facebook.react:react-native:+'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,9 +25,6 @@ android {
     }
 }
 
-def supportLibVersion = getExtOrDefault('supportLibVersion', "28.0.0")
-
 dependencies {
-    implementation "com.android.support:support-compat:$supportLibVersion"
     compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/dk/madslee/imageSequence/RCTResourceDrawableIdHelper.java
+++ b/android/src/main/java/dk/madslee/imageSequence/RCTResourceDrawableIdHelper.java
@@ -3,11 +3,13 @@ package dk.madslee.imageSequence;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import com.facebook.common.util.UriUtil;
+import android.support.v4.content.ContextCompat;
 
-import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
+
+import com.facebook.common.util.UriUtil;
 
 
 public class RCTResourceDrawableIdHelper {
@@ -36,7 +38,7 @@ public class RCTResourceDrawableIdHelper {
 
     public @Nullable Drawable getResourceDrawable(Context context, @Nullable String name) {
         int resId = getResourceDrawableId(context, name);
-        return resId > 0 ? context.getResources().getDrawable(resId) : null;
+        return resId > 0 ? ContextCompat.getDrawable(context, resId) : null;
     }
 
     public Uri getResourceDrawableUri(Context context, @Nullable String name) {

--- a/android/src/main/java/dk/madslee/imageSequence/RCTResourceDrawableIdHelper.java
+++ b/android/src/main/java/dk/madslee/imageSequence/RCTResourceDrawableIdHelper.java
@@ -3,7 +3,7 @@ package dk.madslee.imageSequence;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
IMPORTANT: This PR relies on PR #33.

When I build the Android version of an application I'm developing that is using react-native-image-sequence, I get the following notes during the Gradle build stage:
```
> Task :react-native-fs:compileDebugJavaWithJavac
Note: /Users/scott/Documents/SVN/TotallyRealProjectName/node_modules/react-native-fs/android/src/main/java/com/rnfs/RNFSManager.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
```

Which expands out to the following with full deprecation warning details enabled:
```
> Task :react-native-image-sequence:compileDebugJavaWithJavac
/Users/scott/Documents/SVN/TotallyRealProjectName/node_modules/react-native-image-sequence/android/src/main/java/dk/madslee/imageSequence/RCTResourceDrawableIdHelper.java:47: warning: [deprecation] getDrawable(int) in Resources has been deprecated
            return context.getResources().getDrawable(resId);
                                         ^
1 warning
```

This PR fixes that deprecation warning.