### PR TITLE
fix: iOS last image now is shown after animation completes

### DIFF
--- a/ios/RCTImageSequence/RCTImageSequenceView.m
+++ b/ios/RCTImageSequence/RCTImageSequenceView.m
@@ -63,7 +63,7 @@
 
     [_imagesLoaded removeAllObjects];
 
-    self.image = nil;
+    self.image = images.count > 0 ? images[images.count - 1] : nil;
     self.animationDuration = images.count * (1.0f / _framesPerSecond);
     self.animationImages = images;
     self.animationRepeatCount = _loop ? 0 : 1;


### PR DESCRIPTION
## Problem

Displaying a non-repeating sequence of images on iOS results in the image-view going blank after the animation has finished.

On Android, it *does* retain the last image of the sequence.

## A proposed solution

If the overall UIImageView image is set before the animation has started, the last image stays on screen after the animation is finished.

[stack-overflow uiimageview fix](https://stackoverflow.com/questions/3351857/uiimageview-startanimating-how-do-you-get-it-to-stop-on-the-last-image-in-the-s#answer-3352403)

This also makes the behaviour of iOS the same as Android.

Also, thanks for developing the react-native-image-sequence in the first place :) 
