### PR TITLE
Fix build failing with gradle 6.5+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 


### PR DESCRIPTION
Got this error until I added this locally:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':react-native-image-sequence'.
> Could not resolve all artifacts for configuration ':react-native-image-sequence:classpath'.
   > Could not find com.android.tools.build:gradle:4.1.3.
     Searched in the following locations:
       - https://jcenter.bintray.com/com/android/tools/build/gradle/4.1.3/gradle-4.1.3.pom                                                                                                                       If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.       Required by:
         project :react-native-image-sequence
```
with root `build.gradle`:
```
        classpath 'com.android.tools.build:gradle:4.1.3'
```
and this root `gradle-wrapper.properties`
```
distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
```